### PR TITLE
Surround the $AFP_SIZE_LIMIT variable with double quotes

### DIFF
--- a/start_services.sh
+++ b/start_services.sh
@@ -34,7 +34,7 @@ if [ ! -e /.initialized ]; then
     time machine = yes
     valid users = ${AFP_LOGIN}" >> /usr/local/etc/afp.conf
 
-    if [ -n $AFP_SIZE_LIMIT ]; then
+    if [ -n "$AFP_SIZE_LIMIT" ]; then
         echo "
 	vol size limit = ${AFP_SIZE_LIMIT}" >> /usr/local/etc/afp.conf
     fi


### PR DESCRIPTION
Without double quotes the check if $AFP_SIZE_LIMIT is not set or is empty does not work. See http://stackoverflow.com/a/27596309
