### PR TITLE
Change the foreground process.

### DIFF
--- a/start_services.sh
+++ b/start_services.sh
@@ -46,4 +46,4 @@ fi
 chown -R $AFP_LOGIN:$AFP_LOGIN /timemachine
 netatalk -F /usr/local/etc/afp.conf
 
-/bin/bash
+tail -f /var/log/afpd.log


### PR DESCRIPTION
Instead of "/bin/bash" we should us "tail -f /var/log/afpd.log" as foreground process to keep the docker container alive. "tail -f /var/log/afpd.log" provides useful log messages for the command: docker logs <timemachine-continer>
