### PR TITLE
Change afp name use

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ As the image has been started using the `--restart=always` flag, it will start w
 To add a user, run:
 
 ```
-$ docker exec timemachine add-account USERNAME PASSWORD MOUNT_POINT [VOL_SIZE_MB]
+$ docker exec timemachine add-account USERNAME PASSWORD VOL_NAME MOUNT_POINT [VOL_SIZE_MB]
 ```
 
 But take care that:
+* `VOL_NAME` will be the name of the volume shown on your OSX as the network drive
 * `MOUNT_POINT` should be an absolute path, preferably a sub-path of `/timemachine` (e.g., `/timemachine/backup`), so it will be stored in the according sub-path of your external volume.
 * `VOL_SIZE_MB` is an optional parameter. It indicates the max volume size for that user.
 
@@ -91,7 +92,7 @@ There are these environment variables:
 * **AFP_NAME**: Name of the volume
 * **AFP_SIZE_LIMIT**: Size in MB of the volume (optional)
 
-Using these variables, the container will create a user at boot time (only one per container).
+Using these variables, the container will create a user at boot time (only one per container) and **the data will be stored directly in the volume `/timemachine`, without subfolders**.
 
 
 ## FAQ
@@ -99,7 +100,7 @@ Using these variables, the container will create a user at boot time (only one p
 
 #### I got Docker running, my firewall is configured, but I still don't find the service in Time Machine.
 
-Make sure you actually mount the server volume (see Step 5) before trying to find it in Time Machine settingss.  
+Make sure you actually mount the server volume (see Step 5) before trying to find it in Time Machine settingss.
 
 #### I am still having trouble ...
 

--- a/bin/add-account
+++ b/bin/add-account
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 3 ]]; then
-  echo "Usage: add-user USERNAME PASSWORD MOUNT_POINT [VOL_SIZE_MB]"
+  echo "Usage: add-user USERNAME PASSWORD VOL_NAME MOUNT_POINT [VOL_SIZE_MB]"
   exit 1
 fi
 
@@ -15,10 +15,11 @@ chown -R $1:root $3
 
 # Add config to timemachine
   echo "
-[${1}]
+[${3}]
     path = ${3}
     time machine = yes
-    valid users = ${1}" >> /etc/afp.conf
+    valid users = ${1}
+    spotlight = no" >> /etc/afp.conf
 
 if [[ $# -eq 4 ]]; then
   echo "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ if [ ! -e /.initialized_afp ]; then
 fi
 
 if [ ! -e /.initialized_user ] && [ ! -z $AFP_LOGIN ] && [ ! -z $AFP_PASSWORD ] && [ ! -z $AFP_NAME ]; then
-    add-account $AFP_LOGIN $AFP_PASSWORD $AFP_NAME $AFP_SIZE_LIMIT
+    add-account $AFP_LOGIN $AFP_PASSWORD $AFP_NAME /timemachine $AFP_SIZE_LIMIT
     touch /.initialized_user
 fi
 


### PR DESCRIPTION
Solving #20 and #21 (and possible #17 )

Avoids using `$AFP_NAME` as the mountpoint, which will lead to strange behaviours and data not saved on the right place.