### PR TITLE
Allow UID/GID for backup user

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ To add a user, run:
 $ docker exec timemachine add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
 ```
 
+Or, if you want to add a user with a specific UID/GID, use the following format
+
+```
+$ docker exec timemachine add account -i 1000 -g 1000 USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
+```
+
 But take care that:
 * `VOL_NAME` will be the name of the volume shown on your OSX as the network drive
 * `VOL_ROOT` should be an absolute path, preferably a sub-path of `/timemachine` (e.g., `/timemachine/backup`), so it will be stored in the according sub-path of your external volume.

--- a/bin/add-account
+++ b/bin/add-account
@@ -1,18 +1,32 @@
 #!/bin/bash
 
+while getopts ":i:g:e:" Option
+do
+  case $Option in
+    i ) _uid=$OPTARG ;;
+    g ) _gid=$OPTARG ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
 if [[ $# -lt 4 ]]; then
-  echo "Usage: add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]"
+  echo "Usage: add-account [ -i uid -g gid ] USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]"
   exit 1
 fi
 
-
-# Add the user
-adduser -S -H -G root $1
-echo $1:$2 | chpasswd
-
 # Create mountpoint
 mkdir -p ${4}
-chown -R $1:root ${4}
+
+if [[ $_uid ]] && [[ $_gid ]]; then
+  addgroup -g $_gid $1
+  adduser -u $_uid -S -H $1
+  chown -R $1:$1 ${4}
+else
+  adduser -S -H -G root $1
+  chown -R $1:root ${4}
+fi
+
+echo $1:$2 | chpasswd
 
 # Add config to timemachine
   echo "


### PR DESCRIPTION
- -i and -g can now be passed into add-account to map to real users

I personally prefer to map my UIDs / GIDs to real users on my system, so I added support for that here.