### PR TITLE
ensure supervisord is PID 1

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ if [ ! -e /.initialized_user ] && [ ! -z "$AFP_LOGIN" ] && [ ! -z "$AFP_PASSWORD
     touch /.initialized_user
 fi
 
-/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
The exec ensures that `supervisord` is running as PID 1.  PID 1 must be a program able to reap children and handle other special tasks.

We need a special PID 1 program in order to cleanly shutdown the container.  Currently, `docker stop` doesn't work correctly.

```sh
# Without the patch applied:
bash-4.4# ps
PID   USER     TIME  COMMAND
    1 root      0:00 {entrypoint.sh} /bin/bash /entrypoint.sh
    7 root      0:00 {supervisord} /usr/bin/python2 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.
    9 root      0:00 {start_netatalk.} /bin/bash /start_netatalk.sh
   12 messageb  0:00 dbus-daemon --system
   13 root      0:00 netatalk -d
   14 root      0:00 /usr/bin/afpd -d -F /etc/afp.conf
   15 root      0:00 /usr/bin/cnid_metad -d -F /etc/afp.conf
   16 root      0:00 bash
   22 root      0:00 ps
```

```sh
# With this patch applied:
bash-4.4# ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 {supervisord} /usr/bin/python2 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.
    8 root      0:00 {start_netatalk.} /bin/bash /start_netatalk.sh
   11 messageb  0:00 dbus-daemon --system
   12 root      0:00 netatalk -d
   13 root      0:00 /usr/bin/afpd -d -F /etc/afp.conf
   14 root      0:00 /usr/bin/cnid_metad -d -F /etc/afp.conf
   15 root      0:00 bash
   22 root      0:00 ps aux
```