### PR TITLE
Add user to group when UID/GID is set

### DIFF
--- a/bin/add-account
+++ b/bin/add-account
@@ -19,7 +19,7 @@ mkdir -p ${4}
 
 if [[ $_uid ]] && [[ $_gid ]]; then
   addgroup -g $_gid $1
-  adduser -u $_uid -S -H $1
+  adduser -u $_uid -S -H -G $1 $1
   chown -R $1:$1 ${4}
 else
   adduser -S -H -G root $1


### PR DESCRIPTION
The user environment variables setting was unusable as the group defaulted to `nogroup`. Maybe someone else made it work, but for me the permissions stopped any editing or adding of files from the client connected to the AFP share. With the group set, it’s all good!