### PR TITLE
Add Time Machine quotas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN chmod +x /entrypoint.sh
 ADD bin/add-account /usr/bin/add-account
 ADD config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 ADD config/smb.conf /etc/samba/smb.conf
+ADD config/com.apple.TimeMachine.quota.plist /com.apple.TimeMachine.quota.plist
 
 EXPOSE 137/UDP 138/UDP 139/TCP 445/TCP
 

--- a/README.md
+++ b/README.md
@@ -54,18 +54,19 @@ As the image has been started using the `--restart=always` flag, it will start w
 To add a user, run:
 
 ```
-$ docker exec timemachine add-account USERNAME PASSWORD VOL_NAME VOL_ROOT
+$ docker exec timemachine add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
 ```
 
 Or, if you want to add a user with a specific UID/GID, use the following format
 
 ```
-$ docker exec timemachine add-account -i 1000 -g 1000 USERNAME PASSWORD VOL_NAME VOL_ROOT
+$ docker exec timemachine add-account -i 1000 -g 1000 USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
 ```
 
 But take care that:
 * `VOL_NAME` will be the name of the volume shown on your OSX as the network drive
 * `VOL_ROOT` should be an absolute path, preferably a sub-path of `/timemachine` (e.g., `/timemachine/backup`), so it will be stored in the according sub-path of your external volume.
+* `VOL_SIZE_MB` is an optional parameter. It indicates the max volume size for that user.
 
 
 ### Step 3 - Enable Auto Discovery
@@ -122,6 +123,7 @@ There are these environment variables:
 * **SMB_LOGIN**: User name
 * **SMB_PASSWORD**: User password
 * **SMB_NAME**: Name of the volume
+* **SMB_SIZE_LIMIT**: Size in MB of the volume (optional)
 * **PUID**: For UID
 * **PGID**: For GID
 
@@ -151,8 +153,8 @@ Alternativey, you can script the account creation and upload a custom entrypoint
 set -e
 
 # Repeat for all your accounts
-add-account USERNAME PASSWORD VOL_NAME VOL_ROOT
-add-account USERNAME PASSWORD VOL_NAME VOL_ROOT
+add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
+add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ As the image has been started using the `--restart=always` flag, it will start w
 To add a user, run:
 
 ```
-$ docker exec timemachine add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
+$ docker exec timemachine add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [TM_SIZE_MB]
 ```
 
 Or, if you want to add a user with a specific UID/GID, use the following format
 
 ```
-$ docker exec timemachine add-account -i 1000 -g 1000 USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
+$ docker exec timemachine add-account -i 1000 -g 1000 USERNAME PASSWORD VOL_NAME VOL_ROOT [TM_SIZE_MB]
 ```
 
 But take care that:
 * `VOL_NAME` will be the name of the volume shown on your OSX as the network drive
 * `VOL_ROOT` should be an absolute path, preferably a sub-path of `/timemachine` (e.g., `/timemachine/backup`), so it will be stored in the according sub-path of your external volume.
-* `VOL_SIZE_MB` is an optional parameter. It indicates the max volume size for that user.
+* `TM_SIZE_MB` is an optional parameter. It indicates the max Time Machine size for that user.
 
 
 ### Step 3 - Enable Auto Discovery
@@ -123,7 +123,7 @@ There are these environment variables:
 * **SMB_LOGIN**: User name
 * **SMB_PASSWORD**: User password
 * **SMB_NAME**: Name of the volume
-* **SMB_SIZE_LIMIT**: Size in MB of the volume (optional)
+* **TM_SIZE_LIMIT**: Time Machine size limit in MB (optional)
 * **PUID**: For UID
 * **PGID**: For GID
 
@@ -153,8 +153,8 @@ Alternativey, you can script the account creation and upload a custom entrypoint
 set -e
 
 # Repeat for all your accounts
-add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
-add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]
+add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [TM_SIZE_MB]
+add-account USERNAME PASSWORD VOL_NAME VOL_ROOT [TM_SIZE_MB]
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 ```
 

--- a/bin/add-account
+++ b/bin/add-account
@@ -10,7 +10,7 @@ done
 shift $(($OPTIND - 1))
 
 if [[ $# -lt 4 ]]; then
-  echo "Usage: add-account [ -i uid -g gid ] USERNAME PASSWORD VOL_NAME VOL_ROOT"
+  echo "Usage: add-account [ -i uid -g gid ] USERNAME PASSWORD VOL_NAME VOL_ROOT [VOL_SIZE_MB]"
   exit 1
 fi
 
@@ -43,6 +43,11 @@ echo -e "$2\n$2" | smbpasswd -L -s $1
   kernel share modes = no
   posix locking = no
   vfs objects = catia fruit streams_xattr" >> /etc/samba/smb.conf
+
+if [[ $# -eq 5 ]]; then
+  TM_SIZE=$((${5} * 1000000))
+  sed "s#REPLACE_TM_SIZE#${TM_SIZE}#" /com.apple.TimeMachine.quota.plist > ${4}/.com.apple.TimeMachine.quota.plist
+fi
 
 pkill -HUP smbd
 exit 0

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ ! -e /.initialized_user ] && [ ! -z "$SMB_LOGIN" ] && [ ! -z "$SMB_PASSWORD" ] && [ ! -z "$SMB_NAME" ] && [ ! -z $PUID ] && [ ! -z $PGID ]; then
-    add-account -i $PUID -g $PGID "$SMB_LOGIN" "$SMB_PASSWORD" "$SMB_NAME" /timemachine $SMB_SIZE_LIMIT
+    add-account -i $PUID -g $PGID "$SMB_LOGIN" "$SMB_PASSWORD" "$SMB_NAME" /timemachine $TM_SIZE_LIMIT
     touch /.initialized_user
 fi
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ ! -e /.initialized_user ] && [ ! -z "$SMB_LOGIN" ] && [ ! -z "$SMB_PASSWORD" ] && [ ! -z "$SMB_NAME" ] && [ ! -z $PUID ] && [ ! -z $PGID ]; then
-    add-account -i $PUID -g $PGID "$SMB_LOGIN" "$SMB_PASSWORD" "$SMB_NAME" /timemachine
+    add-account -i $PUID -g $PGID "$SMB_LOGIN" "$SMB_PASSWORD" "$SMB_NAME" /timemachine $SMB_SIZE_LIMIT
     touch /.initialized_user
 fi
 

--- a/config/com.apple.TimeMachine.quota.plist
+++ b/config/com.apple.TimeMachine.quota.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>GlobalQuota</key>
+    <integer>REPLACE_TM_SIZE</integer>
+  </dict>
+</plist>


### PR DESCRIPTION
I've added Time Machine quotas to the Samba version. It takes some time till macOS recognizes the limit, but afterwards it works fine for me.

Inspired by https://github.com/willtho89/docker-samba-timemachine. Kudos to @willtho89.